### PR TITLE
Remove remaining references to Keras

### DIFF
--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -55,7 +55,7 @@ test:
     - requirements.txt
 
   commands:
-    - {{ PYTHON }} -m pip install -r requirements.txt && pytest -v --ignore=keras-retinanet/    # [unix]
+    - {{ PYTHON }} -m pip install -r requirements.txt && pytest -v    # [unix]
     - {{ PYTHON }} -c 'import deepforest; print(deepforest.__version__)'    # [win]
 
 about:

--- a/deepforest/main.py
+++ b/deepforest/main.py
@@ -77,7 +77,7 @@ class deepforest(pl.LightningModule):
         """Use the latest DeepForest model release from github and load model.
         Optionally download if release doesn't exist.
         Returns:
-            model (object): A trained keras model
+            model (object): A trained PyTorch model
         """
         # Download latest model from github release
         release_tag, self.release_state_dict = utilities.use_release()

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -195,11 +195,7 @@ results["box_precision"]
 0.781
 ```
 
-### Loading saved models for prediction
-
-DeepForest uses the keras saving workflow, which means users can save the entire model architecture, or just the weights. For more explanation on Keras see [here](https://stackoverflow.com/questions/42621864/difference-between-keras-model-save-and-model-save-weights).
-
-### Saved Model
+### Saving and loading models
 
 ```
 import tempfile


### PR DESCRIPTION
There were a few residual mentions of Keras (other than the history documentation).
This cleans those up including an old ignore in the testing commands.